### PR TITLE
Publish official docker image post-release of github release packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!Gopkg.lock
+!Gopkg.toml
+!main.go
+!cmd/
+!service/

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,8 @@ deploy:
       condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+-.+$
       repo: itskingori/sanaa
       tags: true
+after_deploy:
+  - "./scripts/trigger.sh ${TRAVIS_TAG}"
+env:
+  global:
+    - secure: QU8cQO//Q15fPApmjmO47OZ6l84KqcFj9V6flGerOEVXvZoPhspE2JbLyit2lhlIsgcC0ljHWviXvjH3DxRmSnlZo9/PlIC+aAQ+g4cqOIgY+o4uEA/opRiXqHIv+ctPvdg5JlRuF8RxFgNX8iRR2lu52btwby4G/oaqI3Dm+G5/NVR3cuIjXc18MciPP50oyiMlScTP28pYKFM+oPxDGrCVOC/Lmwhf3qMGMD+TsdlYtlgMA+gbN/dtZHwqpplhq9yKFdWVF202OnpsFdedOZrjd7NTayiOdYAnwc6DC2JtJk9k3IMfS4uFSAnfhYnVLPoHWNMEfJIKWJR934LQ0ieckEhOJQoW5DeXJ/a9qG8wVtur0PShyNj/Z9v8mj7KTHiGF0gxaW0m5nmrYIT5mZHE97c1Sh3fHt31Fv+tCjaYorCrF4uvNpLff1AfDoy9ZMJJDm/NYX6e5Oc7JIPd/9/eW4oIJn5jmd6Xue6Rs/+O+jrB2KcQOCRIterKSD/JpusrUSS5M+yQVA+/roxEyiOVd0RknWIp8GLIzcWQd5rZM1MoChRstBMzB33Xft3B7q0ufvnsVeReOOtPMHtBk0TJC3yTUNmOtEOnMjf1l2KCSYTvex85jmkhISOrVRn1xfRbGHZPNK2US+EkaxTHii1evfg9YT5DR1T3hmACMP8=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:17.10
+
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+      # build process
+      ca-certificates wget \
+      # wkhtml
+      wkhtmltopdf="0.12.3.2-3" && \
+    rm -f -R /tmp/* /var/{cache,log,tmp} /var/lib/{apt,dpkg,cache,log}
+
+# sanaa
+ARG SANAA_VERSION
+ARG SANAA_PACKAGE="sanaa-${SANAA_VERSION}-linux-amd64"
+RUN wget --progress="dot:mega" "https://github.com/itskingori/sanaa/releases/download/${SANAA_VERSION}/${SANAA_PACKAGE}.tar.gz" && \
+    wget --progress="dot:mega" "https://github.com/itskingori/sanaa/releases/download/${SANAA_VERSION}/${SANAA_PACKAGE}-shasum-256.txt" && \
+    sha256sum -c "${SANAA_PACKAGE}-shasum-256.txt" && \
+    tar --no-same-owner -xzf "${SANAA_PACKAGE}.tar.gz" && \
+    mv "/${SANAA_PACKAGE}" "/usr/local/bin/sanaa" && \
+    chmod +x "/usr/local/bin/sanaa" && \
+    rm -f ${SANAA_PACKAGE}*
+
+ENTRYPOINT ["sanaa"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,6 @@ platform [from the releases page][releases] to any location in your `$PATH` and
 you're good to go.
 
 If using Docker 🐳, there's the `kingori/sanaa` [image on Docker Hub][dockerhub].
-For examples and more information, checkout out [the docker image's
-repository][dockerrepo].
 
 ## Dependencies 🖇️
 
@@ -289,6 +287,8 @@ generator) and it is [hosted on GitHub Pages][github-page]. The code is in the
      normal tags.
    * Compressed binary with a shasum 256 file will be uploaded as attachments to
      the release.
+3. Trigger will start a build on Docker Hub to publish two Docker images:
+   `kingori/sanaa:latest` and `kingori/sanaa:x.y.z`.
 
 ## License 📜
 
@@ -302,7 +302,6 @@ users communicate with it there.
 [contributing]: https://github.com/itskingori/sanaa/blob/master/CONTRIBUTING.md
 [dep]: https://golang.github.io/dep/
 [dockerhub]: https://hub.docker.com/r/kingori/sanaa
-[dockerrepo]: https://github.com/itskingori/docker-sanaa
 [github-page]: https://pages.github.com/
 [jekyll]: http://jekyllrb.com/
 [personal-site]: http://kingori.co/

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Build hook running"
+docker build --build-arg SANAA_VERSION="${SOURCE_BRANCH}" -t "${IMAGE_NAME}" .

--- a/scripts/trigger.sh
+++ b/scripts/trigger.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+version="$1"
+
+# trigger docker hub
+curl -X "POST" "https://registry.hub.docker.com/u/kingori/sanaa/trigger/${DOCKER_HUB_TRIGGER_TOKEN}/" \
+     -d '{"source_type": "Tag", "source_name": "'${version}'"}' \
+     -H "Content-Type: application/json; charset=utf-8" \
+     -sS


### PR DESCRIPTION
Configure automated builds on Docker Hub post-release of the binary. When we tag e.g. `0.1.0-example`, releases will be published on GitHub first ([here][1]) and thereafter a trigger will start a build on Docker Hub resulting in a `kingori/sanaa:0.1.0-example` image [here][2].

[1]: https://github.com/itskingori/sanaa/releases
[2]: https://hub.docker.com/r/kingori/sanaa/