### PR TITLE
Add live and ready health endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.2.0
 
-* Add `/health/live/` (liveness) and `/health/ready/` (readiness) health
-  endpoints on the server component.
+* Add `/health/live` (liveness) and `/health/ready` (readiness) health endpoints
+  on the server component.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+* Add `/health/live/` (liveness) and `/health/ready/` (readiness) health
+  endpoints on the server component.
+
 ## 0.1.0
 
 * First prototype of the idea with basic features i.e. server and worker

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,12 @@
   version = "v1.12.30"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
+
+[[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "4da3e2cfbabc9f751898f250b49f2439785783a1"
@@ -58,6 +64,12 @@
   packages = ["."]
   revision = "67c8dc210ce647e8d8a4206c7f5856ea2390f290"
   version = "v0.5.0"
+
+[[projects]]
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -87,6 +99,12 @@
   revision = "42e33e2d55a0ff1d6263f738896ea8c13571a8d0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/heptiolabs/healthcheck"
+  packages = ["."]
+  revision = "da5fdee475fb09de87c5d4a50da233b7d28767b1"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -109,6 +127,12 @@
   revision = "8d7837e64d3c1ee4e54a880c5a920ab4316fc90a"
 
 [[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   revision = "d0303fe809921458f417bcf828397a65db30a7e4"
@@ -117,6 +141,39 @@
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   revision = "2009e44b6f182e34d8ce081ac2767622937ea3d4"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = ["prometheus"]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "89604d197083d4781071d3c65855d24ecfb0a563"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "282c8707aa210456a825798969cc27edda34992a"
 
 [[projects]]
   name = "github.com/robfig/cron"
@@ -204,6 +261,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8da7c5cb8a35284f3500c91e0863a111f95eae43d1431ddff2f3adae4e4b347f"
+  inputs-digest = "4dc1364845ab208498c11e4eac99ae7ad7b404301a87e15d3393426791258016"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -15,6 +15,10 @@
   version = "1.5.0"
 
 [[constraint]]
+  name = "github.com/heptiolabs/healthcheck"
+  branch = "master"
+
+[[constraint]]
   name = "github.com/itskingori/go-wkhtml"
   version = "1.0.0-rc1"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -251,6 +251,57 @@ the following attributes:
 | `status`      | Status of the job i.e. `pending`, `processing`, `failed`, `succeeded` |
 | `logs`        | Output of processing by the worker, useful when debugging |
 
+### Advanced Usage
+
+#### Health Endpoints
+
+The server component has two health endpoints available:
+
+* `/health/live` -  liveness endpoint, indicates that the server is up.
+* `/health/ready` - readiness endpoint, indicates that server is ready to
+  receive requests.
+
+Pass the `?full=1` query parameter to expose the details of the check in the
+JSON response. These are omitted by default for performance.
+
+Also note that both endpoints return the appropriate response conveying the
+health of the service. To demonstrate this, make a request to the readiness
+endpoint:
+
+```http
+GET /health/ready?full=1 HTTP/1.1
+Host: 127.0.0.1:8080
+Connection: close
+```
+
+If redis is up, you should get a `200 OK` HTTP response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Date: Thu, 22 Feb 2018 19:54:41 GMT
+Content-Length: 37
+Connection: close
+
+{
+    "redis-tcp-connection": "OK"
+}
+```
+
+If redis is down, you should get a `503 Service Unavailable` HTTP response:
+
+```http
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json; charset=utf-8
+Date: Thu, 22 Feb 2018 20:00:27 GMT
+Content-Length: 87
+Connection: close
+
+{
+    "redis-tcp-connection": "dial tcp 127.0.0.1:6379: connect: connection refused"
+}
+```
+
 ## Development ⚒️
 
 Below instructions are only necessary if you intend to work on the source code

--- a/service/server.go
+++ b/service/server.go
@@ -303,6 +303,12 @@ func (clt *Client) StartServer() {
 
 	health := healthcheck.NewHandler()
 
+	redis_address := viper.GetString("redis.host")
+	redis_port := viper.GetInt("redis.port")
+	redis_host := fmt.Sprintf("%s:%d", redis_address, redis_port)
+	redis_tcp_check := healthcheck.TCPDialCheck(redis_host, 50*time.Millisecond)
+	health.AddReadinessCheck("redis-tcp-connection", redis_tcp_check)
+
 	router := mux.NewRouter()
 	router.HandleFunc("/health/live", health.LiveEndpoint).
 		Methods("GET")

--- a/service/server.go
+++ b/service/server.go
@@ -303,11 +303,11 @@ func (clt *Client) StartServer() {
 
 	health := healthcheck.NewHandler()
 
-	redis_address := viper.GetString("redis.host")
-	redis_port := viper.GetInt("redis.port")
-	redis_host := fmt.Sprintf("%s:%d", redis_address, redis_port)
-	redis_tcp_check := healthcheck.TCPDialCheck(redis_host, 50*time.Millisecond)
-	health.AddReadinessCheck("redis-tcp-connection", redis_tcp_check)
+	redisAddress := viper.GetString("redis.host")
+	redisPort := viper.GetInt("redis.port")
+	redisHost := fmt.Sprintf("%s:%d", redisAddress, redisPort)
+	redisTCPCheck := healthcheck.TCPDialCheck(redisHost, 50*time.Millisecond)
+	health.AddReadinessCheck("redis-tcp-connection", redisTCPCheck)
 
 	router := mux.NewRouter()
 	router.HandleFunc("/health/live", health.LiveEndpoint).
@@ -321,9 +321,9 @@ func (clt *Client) StartServer() {
 		Headers("Content-Type", "application/json").
 		Methods("GET")
 
-	binding_address := viper.GetString("server.binding_address")
-	binding_port := viper.GetInt("server.binding_port")
-	binding := fmt.Sprintf("%s:%d", binding_address, binding_port)
+	bindingAddress := viper.GetString("server.binding_address")
+	bindingPort := viper.GetInt("server.binding_port")
+	binding := fmt.Sprintf("%s:%d", bindingAddress, bindingPort)
 
 	log.Infof("Listening on http://%s", binding)
 	http.Handle("/", router)

--- a/service/server.go
+++ b/service/server.go
@@ -301,11 +301,6 @@ func (clt *Client) StartServer() {
 	requestTTL := viper.GetInt("server.request_ttl")
 	log.Infof("Request TTL set to %d seconds", requestTTL)
 
-	binding_address := viper.GetString("server.binding_address")
-	binding_port := viper.GetInt("server.binding_port")
-	binding := fmt.Sprintf("%s:%d", binding_address, binding_port)
-	log.Infof("Listening on http://%s", binding)
-
 	health := healthcheck.NewHandler()
 
 	router := mux.NewRouter()
@@ -320,6 +315,11 @@ func (clt *Client) StartServer() {
 		Headers("Content-Type", "application/json").
 		Methods("GET")
 
+	binding_address := viper.GetString("server.binding_address")
+	binding_port := viper.GetInt("server.binding_port")
+	binding := fmt.Sprintf("%s:%d", binding_address, binding_port)
+
+	log.Infof("Listening on http://%s", binding)
 	http.Handle("/", router)
 	http.ListenAndServe(binding, nil)
 }

--- a/service/server.go
+++ b/service/server.go
@@ -300,9 +300,9 @@ func (clt *Client) StartServer() {
 	requestTTL := viper.GetInt("server.request_ttl")
 	log.Infof("Request TTL set to %d seconds", requestTTL)
 
-	address := viper.GetString("server.binding_address")
-	port := viper.GetInt("server.binding_port")
-	binding := fmt.Sprintf("%s:%d", address, port)
+	binding_address := viper.GetString("server.binding_address")
+	binding_port := viper.GetInt("server.binding_port")
+	binding := fmt.Sprintf("%s:%d", binding_address, binding_port)
 	log.Infof("Listening on http://%s", binding)
 
 	router := mux.NewRouter()

--- a/service/server.go
+++ b/service/server.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/heptiolabs/healthcheck"
 	"github.com/satori/go.uuid"
 	"github.com/spf13/viper"
 
@@ -305,7 +306,13 @@ func (clt *Client) StartServer() {
 	binding := fmt.Sprintf("%s:%d", binding_address, binding_port)
 	log.Infof("Listening on http://%s", binding)
 
+	health := healthcheck.NewHandler()
+
 	router := mux.NewRouter()
+	router.HandleFunc("/health/live", health.LiveEndpoint).
+		Methods("GET")
+	router.HandleFunc("/health/ready", health.ReadyEndpoint).
+		Methods("GET")
 	router.HandleFunc("/render/{target}", clt.renderHandler).
 		Headers("Content-Type", "application/json").
 		Methods("POST")


### PR DESCRIPTION
Adds two endpoints:

* `/health/live` -  liveness endpoint, indicates that the server is up.
* `/health/ready` - readiness endpoint, indicates that server is ready to receive requests.

Closes https://github.com/itskingori/sanaa/issues/15.