### PR TITLE
Respond with 500 if server can't enqueue the job

### DIFF
--- a/service/image.go
+++ b/service/image.go
@@ -34,6 +34,8 @@ func (rr *imageRenderRequest) save(riq string, c *Client) (ConversionJob, error)
 	cj, err := c.createAndSaveConversionJob(riq, rr)
 	if err != nil {
 		log.Error(err)
+
+		return cj, err
 	}
 
 	return cj, nil

--- a/service/pdf.go
+++ b/service/pdf.go
@@ -33,6 +33,8 @@ func (rr *pdfRenderRequest) save(riq string, c *Client) (ConversionJob, error) {
 	cj, err := c.createAndSaveConversionJob(riq, rr)
 	if err != nil {
 		log.Error(err)
+
+		return cj, err
 	}
 
 	return cj, nil


### PR DESCRIPTION
Closes https://github.com/itskingori/sanaa/issues/24. Now the server with respond with `500 Internal Server Error` if it's unable to queue e.g. if redis is down.

```console
$ ./sanaa server --verbose
INFO[0000] Starting the server
INFO[0000] Request TTL set to 86400 seconds
INFO[0000] Listening on http://0.0.0.0:8080
ERRO[0039] Error saving conversion job                   uuid=d711d933-faa2-48f7-9abb-cf37aa1ba439
ERRO[0039] dial tcp 127.0.0.1:6379: connect: connection refused
ERRO[0039] Unable to enqueue image job                   uuid=d711d933-faa2-48f7-9abb-cf37aa1ba439
ERRO[0039] 500 Internal Server Error                     uuid=d711d933-faa2-48f7-9abb-cf37aa1ba439
```